### PR TITLE
Initial CSharp implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/Src/CSharp/obj
+/Src/CSharp/bin
+/Src/CSharp/.vs

--- a/Src/CSharp/ISignal.cs
+++ b/Src/CSharp/ISignal.cs
@@ -1,0 +1,69 @@
+//------------------------------------------------------------------------------
+// <copyright file="ISignalFeedback.cs" company="Silicon Dream Artists">
+//     Copyright (c) Silicon Dream Artists. All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace SignalCore
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Extensions.Logging;
+
+    public interface ISignal
+    {
+        IEnumerable<SignalFeedbackEntry> CriticalEntries { get; }
+
+        IEnumerable<string> CriticalEntryMessages { get; }
+
+        string CriticalSummary { get; }
+
+        List<SignalFeedbackEntry> Entries { get; set; }
+
+        IEnumerable<string> EntryMessages { get; }
+
+        SignalFeedbackLevel Level { get; set; }
+
+        bool Failure { get; }
+
+        string LevelName { get; }
+
+        bool Success { get; }
+
+        IDisposable BeginScope<TState>(TState state);
+
+        bool CheckForLevelFailure(bool allowEquals = false, SignalFeedbackLevel passingSeverity = SignalFeedbackLevel.Warning);
+
+        bool CheckForLevelSuccess(bool allowEquals = true, SignalFeedbackLevel passingSeverity = SignalFeedbackLevel.Warning);
+
+        string GetExceptionMessage(Exception ex);
+
+        IEnumerable<string> GetFeedbackEntries(SignalFeedbackLevel minimumSeverityToGet);
+
+        Signal MergeFeedback(params Signal[] priorExecutionResults);
+
+        bool MergeFeedbackAndCheckForFail(params Signal[] priorExecutionResults);
+
+        bool MergeFeedbackAndCheckForSuccess(params Signal[] priorExecutionResults);
+
+        bool IsEnabled(LogLevel logLevel);
+
+        void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter);
+
+        SignalFeedbackEntry LogCritical(string message, Exception exception = null);
+
+        SignalFeedbackEntry LogInformation(string message, Exception exception = null);
+
+        SignalFeedbackEntry LogMessage(SignalFeedbackLevel severity, string message, Exception exception = null);
+
+        SignalFeedbackEntry LogWarning(string message, Exception exception = null);
+
+        SignalFeedbackLevel SetFeedbackLevel();
+
+        SignalFeedbackLevel SetFeedbackLevel(SignalFeedbackLevel signalLevel);
+
+        void CreateFeedbackEntry(SignalFeedbackLevel severity, string message, Exception exception = null);
+
+        string ToJson();
+    }
+}

--- a/Src/CSharp/ISignalFeedbackEntry.cs
+++ b/Src/CSharp/ISignalFeedbackEntry.cs
@@ -1,0 +1,18 @@
+// <copyright file="ISignalFeedbackEntry.cs" company="Silicon Dream Artists">
+//     Copyright (c) Silicon Dream Artists. All rights reserved.
+// </copyright>
+
+namespace SignalCore
+{
+    using System;
+
+    public interface ISignalFeedbackEntry
+    {
+        string Message { get; set; }
+        string MessageFull { get; set; }
+        SignalFeedbackLevel Level { get; set; }
+        SignalFeedbackNature Nature { get; set; }
+
+        Exception Exception { get; set; }
+    }
+}

--- a/Src/CSharp/ISignal{T}.cs
+++ b/Src/CSharp/ISignal{T}.cs
@@ -1,0 +1,14 @@
+//------------------------------------------------------------------------------
+// <copyright file="ISignal{T}.cs" company="Silicon Dream Artists">
+//     Copyright (c) Silicon Dream Artists. All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace SignalCore
+{
+    public interface ISignal<T> : ISignal
+    {
+        T Result { get; set; }
+        bool HasValue { get; }
+    }
+}

--- a/Src/CSharp/Signal-Core.csproj
+++ b/Src/CSharp/Signal-Core.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>SignalCore</RootNamespace>
+    <AssemblyName>SignalCore</AssemblyName>
+    <Authors>Silicon Dream Artists</Authors>
+    <Company>Silicon Dream Artists</Company>
+    <Version>1.0.0</Version>
+    <PackageId>Signal-Core</PackageId>
+    <Description>Universal Signal format for decentralized, verifiable intent execution. Part of the SovereignTrust protocol suite.</Description>
+    <PackageTags>signal sovereigntrust messaging protocol decentralized trust</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <RepositoryUrl>https://github.com/SiliconDreamArtists/signal-core</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/Src/CSharp/Signal-Core.sln
+++ b/Src/CSharp/Signal-Core.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33419.255
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SignalCore", "SignalCore.csproj", "{F6C76C99-2F6D-4B63-BE13-5AFBFC61FA43}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F6C76C99-2F6D-4B63-BE13-5AFBFC61FA43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6C76C99-2F6D-4B63-BE13-5AFBFC61FA43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6C76C99-2F6D-4B63-BE13-5AFBFC61FA43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6C76C99-2F6D-4B63-BE13-5AFBFC61FA43}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Src/CSharp/Signal.cs
+++ b/Src/CSharp/Signal.cs
@@ -1,0 +1,308 @@
+//------------------------------------------------------------------------------
+// <copyright file="Signal.cs" company="Silicon Dream Artists">
+//     Copyright (c) Silicon Dream Artists. All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace SignalCore
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Runtime.Serialization;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+
+    [DataContract]
+    public partial class Signal : ILogger, ISignal
+    {
+        private const SignalFeedbackLevel FailureLevel = SignalFeedbackLevel.Critical;
+
+        private const SignalFeedbackLevel SuccessLevel = SignalFeedbackLevel.Retry;
+
+        private static ILogger logger;
+
+        private List<SignalFeedbackEntry> entries;
+
+        public Signal()
+        {
+        }
+
+        public Signal(params Signal[] priorSignals)
+        {
+            this.MergeFeedback(priorSignals);
+        }
+
+        public static bool HasLogger => logger != null;
+
+        public static ILogger Logger
+        {
+            get
+            {
+                if (!HasLogger)
+                {
+                    throw new Exception("Logger must be initialized.");
+                }
+
+                return logger;
+            }
+
+            set
+            {
+                logger = value;
+            }
+        }
+
+        [DataMember]
+        public SignalFeedbackLevel Level { get; set; }
+
+        [DataMember]
+        public string LevelName => this.Level.ToString();
+
+        [DataMember]
+        public List<SignalFeedbackEntry> Entries
+        {
+            get
+            {
+                this.entries = this.entries ?? new List<SignalFeedbackEntry>();
+                return this.entries;
+            }
+
+            set
+            {
+                this.entries = value;
+            }
+        }
+
+        public IEnumerable<string> EntryMessages => this.GetFeedbackEntries(SignalFeedbackLevel.Unspecified);
+
+        public IEnumerable<string> CriticalEntryMessages => this.GetFeedbackEntries(SignalFeedbackLevel.Critical);
+
+        public IEnumerable<SignalFeedbackEntry> CriticalEntries => this.Entries.ToList().Where(x => x.Level == SignalFeedbackLevel.Critical);
+
+        [DataMember]
+        public string CriticalSummary => string.Join(",", this.Entries.ToList().Where(x => x.Level >= SignalFeedbackLevel.Critical).Select(x => x.Message));
+
+        public bool Failure => this.CheckForLevelFailure();
+
+        public bool Success => this.CheckForLevelSuccess();
+
+        public static Signal Start(Signal importExecutionResults = null)
+        {
+            return new Signal(importExecutionResults);
+        }
+
+        public static Signal Start(SignalFeedbackLevel signalLevel, string message, Exception ex = null, params Signal[] priorExecutionResults)
+        {
+            Signal result = new Signal(priorExecutionResults);
+            result.LogMessage(signalLevel, message, ex);
+            return result;
+        }
+
+        public static Signal<T> Start<T>(T defaultResult = default, params Signal[] priorExecutionResults)
+        {
+            Signal<T> result = new Signal<T>(defaultResult, priorExecutionResults);
+            return result;
+        }
+
+        public static Signal<T> Start<T>(T defaultResult, SignalFeedbackLevel signalLevel, string logMessage, params Signal[] priorExecutionResults)
+        {
+            return Start<T>(defaultResult, signalLevel, null, logMessage, priorExecutionResults);
+        }
+
+        public static Signal<T> Start<T>(T defaultResult, SignalFeedbackLevel signalLevel, Exception ex, string logMessage, params Signal[] priorExecutionResults)
+        {
+            Signal<T> result = new Signal<T>(defaultResult, priorExecutionResults);
+            result.LogMessage(signalLevel, logMessage, ex);
+            return result;
+        }
+
+        public void CreateFeedbackEntry(SignalFeedbackLevel severity, string message, Exception exception = null)
+        {
+            switch (severity)
+            {
+                case SignalFeedbackLevel.Information:
+                    {
+                        Logger.LogInformation(message);
+                    }
+
+                    break;
+
+                case SignalFeedbackLevel.Warning:
+                    {
+                        Logger.LogWarning(message);
+                    }
+
+                    break;
+
+
+                case SignalFeedbackLevel.Retry:
+                    {
+                        Logger.LogWarning("Retry: " + message);
+                    }
+
+                    break;
+
+                case SignalFeedbackLevel.Critical:
+                    {
+                        Logger.LogError(exception, message);
+                    }
+
+                    break;
+            }
+        }
+
+        public IEnumerable<string> GetFeedbackEntries(SignalFeedbackLevel minimumSeverityToGet)
+        {
+            this.entries = this.entries ?? new List<SignalFeedbackEntry>();
+            return this.entries.ToList().Where(x => x.Level >= minimumSeverityToGet).Select(x => $"<{x.Level}>{x.Message}" + this.GetExceptionMessage(x.Exception));
+        }
+
+        public string GetExceptionMessage(Exception ex)
+        {
+            if (ex == null)
+            {
+                return string.Empty;
+            }
+
+            return $" - {ex.Message}";
+        }
+
+        public bool MergeFeedbackAndCheckForFail(params Signal[] mergeFeedback)
+        {
+            this.MergeFeedback(mergeFeedback);
+            return this.Failure;
+        }
+
+        public bool MergeFeedbackAndCheckForSuccess(params Signal[] mergeFeedback)
+        {
+            this.MergeFeedback(mergeFeedback);
+            return this.Success;
+        }
+
+        public Signal MergeFeedback(params Signal[] mergeFeedback)
+        {
+            foreach (Signal priorExecutionResult in mergeFeedback.ToList())
+            {
+                if (priorExecutionResult?.entries != null && priorExecutionResult.entries.Count > 0)
+                {
+                    this.Entries.AddRange(priorExecutionResult.entries);
+                    this.SetFeedbackLevel();
+                }
+            }
+
+            return this;
+        }
+
+        public SignalFeedbackEntry LogInformation(string message, Exception exception = null)
+        {
+            return this.LogMessage(SignalFeedbackLevel.Information, message, exception);
+        }
+
+        public SignalFeedbackEntry LogWarning(string message, Exception exception = null)
+        {
+            return this.LogMessage(SignalFeedbackLevel.Warning, message, exception);
+        }
+
+        public SignalFeedbackEntry LogRetry(string message, Exception exception = null)
+        {
+            return this.LogMessage(SignalFeedbackLevel.Retry, message, exception);
+        }
+
+        public SignalFeedbackEntry LogVerbose(string message, Exception exception = null)
+        {
+            return this.LogMessage(SignalFeedbackLevel.VerboseInformation, message, exception);
+        }
+
+        public SignalFeedbackEntry LogCritical(string message, Exception exception = null)
+        {
+            return this.LogMessage(SignalFeedbackLevel.Critical, message, exception);
+        }
+
+        public SignalFeedbackEntry LogMessage(SignalFeedbackLevel severity, string message, Exception exception = null)
+        {
+            var newMessage = new SignalFeedbackEntry(severity, message, exception);
+            this.Entries.Add(newMessage);
+            this.CreateFeedbackEntry(severity, message, exception);
+            this.SetFeedbackLevel(severity);
+            return newMessage;
+        }
+
+        public SignalFeedbackLevel SetFeedbackLevel()
+        {
+            if (this.entries == null || this.entries.Count == 0)
+            {
+                this.Level = SignalFeedbackLevel.Information;
+            }
+            else
+            {
+                var maxLevel = this.Entries.ToList()?.Max(x => x.Level);
+                this.Level = maxLevel ?? SignalFeedbackLevel.Information;
+            }
+
+            return this.Level;
+        }
+
+        public SignalFeedbackLevel SetFeedbackLevel(SignalFeedbackLevel signalLevel)
+        {
+            this.Level = signalLevel > this.Level ? signalLevel : this.Level;
+            return this.Level;
+        }
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (this.IsEnabled(logLevel))
+            {
+                switch (logLevel)
+                {
+                    case LogLevel.Information:
+                        {
+                            Logger.LogInformation(formatter.Invoke(state, exception));
+                        }
+
+                        break;
+
+                    case LogLevel.Warning:
+                        {
+                            Logger.LogWarning(formatter.Invoke(state, exception));
+                        }
+
+                        break;
+
+                    case LogLevel.Critical:
+                        {
+                            Logger.LogError(exception, formatter.Invoke(state, exception));
+                        }
+
+                        break;
+                }
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool CheckForLevelFailure(bool allowEquals = false, SignalFeedbackLevel passingSeverity = SuccessLevel)
+        {
+            return this.Level > passingSeverity || (allowEquals && this.Level == passingSeverity);
+        }
+
+        public bool CheckForLevelSuccess(bool allowEquals = true, SignalFeedbackLevel passingSeverity = SuccessLevel)
+        {
+            return this.Level < passingSeverity || (allowEquals && this.Level == passingSeverity);
+        }
+
+        public string ToJson()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+        public static Signal FromJson(string json) => JsonConvert.DeserializeObject<Signal>(json);
+    }
+}

--- a/Src/CSharp/SignalCore.csproj
+++ b/Src/CSharp/SignalCore.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>SignalCore</RootNamespace>
+    <AssemblyName>Signal.Core</AssemblyName>
+    <Authors>Silicon Dream Artists</Authors>
+    <Company>Silicon Dream Artists</Company>
+    <Version>1.0.0</Version>
+    <PackageId>SovereignTrust-SignalCore</PackageId>
+    <Description>Universal Signal format for decentralized, verifiable intent execution. Part of the SovereignTrust protocol suite.</Description>
+    <PackageTags>signal sovereigntrust messaging protocol decentralized trust</PackageTags>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <RepositoryUrl>https://github.com/SiliconDreamArtists/signal-core</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/Src/CSharp/SignalFeedbackEntry.cs
+++ b/Src/CSharp/SignalFeedbackEntry.cs
@@ -1,0 +1,69 @@
+//------------------------------------------------------------------------------
+// <copyright file="SignalFeedbackEntry.cs" company="Silicon Dream Artists">
+//     Copyright (c) Silicon Dream Artists. All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace SignalCore
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    [DataContract]
+    public class SignalFeedbackEntry : ISignalFeedbackEntry
+    {
+        public SignalFeedbackEntry()
+        {
+            this.CreatedDate = DateTime.Now;
+        }
+
+        public SignalFeedbackEntry(SignalFeedbackLevel severity, string message, Exception exception = null)
+        {
+            this.CreatedDate = DateTime.Now;
+            this.Level = severity;
+            this.Message = message;
+            this.Exception = exception;
+        }
+
+        public SignalFeedbackEntry(SignalFeedbackLevel severity, string message, SignalFeedbackNature nature, Exception exception = null)
+        {
+            this.CreatedDate = DateTime.Now;
+            this.Level = severity;
+            this.Nature = nature;
+            this.Message = message;
+            this.Exception = exception;
+        }
+
+        public Exception Exception { get; set; }
+
+        [DataMember]
+        public string Message { get; set; }
+
+        [DataMember]
+        public string MessageFull { get; set; }
+
+        [DataMember]
+        public SignalFeedbackLevel Level { get; set; }
+
+        [DataMember]
+        public SignalFeedbackNature Nature { get; set; }
+
+        [DataMember]
+        public DateTime? CreatedDate { get; set; }
+
+        [DataMember]
+        public DateTime? LastModifiedDate { get; set; }
+
+        [DataMember]
+        public string CreatedBy { get; set; }
+
+        [DataMember]
+        public string LastModifiedBy { get; set; }
+
+        [DataMember]
+        public Guid Version { get; set; }
+
+        [DataMember]
+        public bool IsReadOnly { get; set; }
+    }
+}

--- a/Src/CSharp/SignalFeedbackEntryComparer.cs
+++ b/Src/CSharp/SignalFeedbackEntryComparer.cs
@@ -1,0 +1,21 @@
+// <copyright file="SignalFeedbackEntryComparer.cs" company="Silicon Dream Artists">
+//     Copyright (c) Silicon Dream Artists. All rights reserved.
+// </copyright>
+
+namespace SignalCore
+{
+    using System.Collections.Generic;
+
+    public class SignalFeedbackEntryComparer : IEqualityComparer<SignalFeedbackEntry>
+    {
+        public bool Equals(SignalFeedbackEntry g1, SignalFeedbackEntry g2)
+        {
+            return g1.CreatedDate == g2.CreatedDate && g1.Message == g2.Message && g1.Nature == g2.Nature;
+        }
+
+        public int GetHashCode(SignalFeedbackEntry g)
+        {
+            return (g.CreatedDate.ToString() + g.Message + g.Nature.ToString()).GetHashCode();
+        }
+    }
+}

--- a/Src/CSharp/SignalFeedbackLevel.cs
+++ b/Src/CSharp/SignalFeedbackLevel.cs
@@ -1,0 +1,23 @@
+// <copyright file="SignalFeedbackLevel.cs" company="Silicon Dream Artists">
+//     Copyright (c) Silicon Dream Artists. All rights reserved.
+// </copyright>
+
+namespace SignalCore
+{
+    public enum SignalFeedbackLevel
+    {
+        Unspecified = 0,
+
+        SensitiveInformation = 1,
+
+        VerboseInformation = 2,
+
+        Information = 4,
+
+        Warning = 8,
+
+        Retry = 16,
+
+        Critical = 32,
+    }
+}

--- a/Src/CSharp/SignalFeedbackNature.cs
+++ b/Src/CSharp/SignalFeedbackNature.cs
@@ -1,0 +1,19 @@
+// <copyright file="SignalFeedbackNature.cs" company="Silicon Dream Artists">
+//     Copyright (c) Silicon Dream Artists. All rights reserved.
+// </copyright>
+
+namespace SignalCore
+{
+    public enum SignalFeedbackNature
+    {
+        Unspecified = 0,
+
+        Code = 1,
+
+        Content = 8,
+
+        Operations = 2,
+
+        Security = 4,
+    }
+}

--- a/Src/CSharp/Signal{T}.cs
+++ b/Src/CSharp/Signal{T}.cs
@@ -1,0 +1,46 @@
+//------------------------------------------------------------------------------
+// <copyright file="Signal{T}.cs" company="Silicon Dream Artists">
+//     Copyright (c) Silicon Dream Artists. All rights reserved.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace SignalCore
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    public class Signal<T> : Signal, ISignal<T>
+    {
+        public Signal()
+        {
+            try
+            {
+                this.Result = (T)Activator.CreateInstance(typeof(T));
+            }
+            catch
+            {
+                // Swallow creation error.
+            }
+        }
+
+        public Signal(bool createDefaultResult = true, params Signal[] priorExecutionResults)
+            : base(priorExecutionResults)
+        {
+            if (createDefaultResult)
+            {
+                this.Result = (T)Activator.CreateInstance(typeof(T));
+            }
+        }
+
+        public Signal(T defaultResult, params Signal[] priorExecutionResults)
+            : base(priorExecutionResults)
+        {
+            this.Result = defaultResult;
+        }
+
+        [DataMember]
+        public T Result { get; set; }
+
+        public bool HasValue => this.Result != null;
+    }
+}

--- a/Src/PowerShell/SignalCore.psm1
+++ b/Src/PowerShell/SignalCore.psm1
@@ -1,0 +1,106 @@
+# Signal.psm1 - PowerShell-native implementation of the Signal format
+
+$Global:SignalFeedbackLevelMap = @{
+    Unspecified           = 0
+    SensitiveInformation  = 1
+    VerboseInformation    = 2
+    Information           = 4
+    Warning               = 8
+    Retry                 = 16
+    Critical              = 32
+}
+
+$Global:SignalFeedbackNatureMap = @{
+    Unspecified = 0
+    Code        = 1
+    Operations  = 2
+    Security    = 4
+    Content     = 8
+}
+
+function New-Signal {
+    param (
+        [string]$Name = "Unnamed",
+        [object]$Result = $null
+    )
+    return [PSCustomObject]@{
+        PSTypeName = 'Signal'
+        Name       = $Name
+        Result     = $Result
+        Level      = 'Information'
+        Entries    = @()
+    }
+}
+
+function Add-SignalEntry {
+    param (
+        [Parameter(Mandatory)] $Signal,
+        [Parameter(Mandatory)][ValidateSet("Unspecified", "SensitiveInformation", "VerboseInformation", "Information", "Warning", "Retry", "Critical")] [string]$Level,
+        [Parameter(Mandatory)] [string]$Message,
+        [Parameter()][ValidateSet("Unspecified", "Code", "Operations", "Security", "Content")] [string]$Nature = 'Unspecified',
+        [Parameter()][Exception]$Exception
+    )
+
+    $entry = [PSCustomObject]@{
+        Level       = $Level
+        LevelValue  = $SignalFeedbackLevelMap[$Level]
+        Nature      = $Nature
+        NatureValue = $SignalFeedbackNatureMap[$Nature]
+        Message     = $Message
+        Exception   = $Exception?.Message
+        CreatedDate = (Get-Date).ToString("o")
+    }
+
+    $Signal.Entries += $entry
+
+    if ($SignalFeedbackLevelMap[$Level] -ge $SignalFeedbackLevelMap['Critical']) {
+        $Signal.Level = 'Critical'
+    } elseif ($SignalFeedbackLevelMap[$Level] -ge $SignalFeedbackLevelMap['Warning'] -and $Signal.Level -ne 'Critical') {
+        $Signal.Level = 'Warning'
+    }
+
+    return $entry
+}
+
+function Merge-Signal {
+    param (
+        [Parameter(Mandatory)] $Target,
+        [Parameter(Mandatory)] $Sources
+    )
+
+    foreach ($source in $Sources) {
+        if ($source.Entries) {
+            $Target.Entries += $source.Entries
+            if ($SignalFeedbackLevelMap[$source.Level] -ge $SignalFeedbackLevelMap['Critical']) {
+                $Target.Level = 'Critical'
+            } elseif ($SignalFeedbackLevelMap[$source.Level] -ge $SignalFeedbackLevelMap['Warning'] -and $Target.Level -ne 'Critical') {
+                $Target.Level = 'Warning'
+            }
+        }
+    }
+
+    return $Target
+}
+
+function Get-SignalStatus {
+    param (
+        [Parameter(Mandatory)] $Signal
+    )
+    return if ($Signal.Level -eq 'Critical') { 'Failure' } else { 'Success' }
+}
+
+function ConvertTo-SignalJson {
+    param (
+        [Parameter(Mandatory)] $Signal
+    )
+    return $Signal | ConvertTo-Json -Depth 10 -Compress
+}
+
+function ConvertFrom-SignalJson {
+    param (
+        [Parameter(Mandatory)] [string]$Json
+    )
+    return $Json | ConvertFrom-Json -Depth 10
+}
+
+Export-ModuleMember -Function New-Signal, Add-SignalEntry, Merge-Signal, Get-SignalStatus, ConvertTo-SignalJson, ConvertFrom-SignalJson


### PR DESCRIPTION
Initial release of SignalCore — a universal result/feedback protocol for verifiable execution

- Introduced core Signal class with severity level, feedback entry list, and result payload
- Added Signal<T> for typed result support with default object handling
- Implemented SignalFeedbackEntry with message, nature, exception, and timestamp metadata
- Included SignalFeedbackLevel and SignalFeedbackNature enums for structured feedback
- Added SignalFeedbackEntryComparer for deduplicating feedback on merge (based on CreatedDate)
- Supports JSON roundtrip via Newtonsoft.Json
- Includes inline logger integration (ILogger) with level-aware log methods
- Ready for NuGet packaging: MIT licensed, versioned 1.0.0, metadata aligned with SovereignTrust

This commit establishes the base protocol layer for Signal communication between agents and services.